### PR TITLE
Allows to not en/decrypt tuples on some commands

### DIFF
--- a/aes.h
+++ b/aes.h
@@ -7,6 +7,7 @@
 
 #define AES_ENCRYPT_FLAG	0
 #define AES_DECRYPT_FLAG	1
+#define AES_NOCRYPT_FLAG	2
 
 
 int AES_CBC_encrypt(unsigned char *plaintext, int plaintext_len,


### PR DESCRIPTION
Commands can be flagged with SetNotEncryptDecryptTTS() to tells the table AM to not encrypt or decrypt tuples from TTS when writing or reading.

Flags are identified by the couple CurrentTransactionId / CurrentCommandId and stored in a local to backend HTAB.

This is useful for VACUUM FULL/CLUSTER, in this case we do not desire to decrypt / encrypt the tuples but just want to rewrite them without touching them.