### PR TITLE
CREATE TABLE AS statement support

### DIFF
--- a/aes.h
+++ b/aes.h
@@ -5,6 +5,7 @@
 #define AES_IVLEN			16
 #define AES_KEYLEN			32
 
+#define AES_INVALID_FLAG	-1
 #define AES_ENCRYPT_FLAG	0
 #define AES_DECRYPT_FLAG	1
 #define AES_NOCRYPT_FLAG	2

--- a/kms.h
+++ b/kms.h
@@ -7,6 +7,7 @@
 #define AT_MOV_KEY		3
 #define AT_DEL_NSP_KEY  4
 #define AT_MOV_NSP_KEY  5
+#define AT_ADD_CTAS_KEY 6
 
 /* Shared memory lock for master keys hash table */
 typedef struct ShmemKMSMasterKeysLock {
@@ -30,6 +31,7 @@ typedef struct KMSKeyAction {
 	char		   *new_relname;
 	char		   *new_nspname;
 	int				action_tag;
+	unsigned char  *ctas_key;
 } KMSKeyAction;
 
 typedef struct KMSKeyCacheEntry {


### PR DESCRIPTION
This commit introduces support of CREATE TABLE .. USING tcleam AS ..
statements.

CTAS is a special case that needs a transient AES key built right
before the statement is executed by standard_ProcessUtility(). To
handle this transient key the local HTAB has been reviewed: we do
not rely anymore on CurrentCommandId and CurrentTransactionID as key
because they are not set before standard_ProcessUtility(), so we
now rely on local transaction id (lxid). Relying only on lxid does
not guarantee unicity of HTAB entries built inside the same
transaction, but it does not matter because if current command
succeeds, its HTAB entry will be removed, then the HTAB key (lxid)
can be safely reused. If current command fails, the transaction is
aborted and the HTAB destroyed.