### PR TITLE
Allows CREATE EXTENSION tcle IN schemaname

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHLIB_LINK += $(filter -lssl -lcrypto -lssleay32 -leay32, $(LIBS))
 
 PGFILEDESC = "TCLE - Transparent Cell-Level Encryption"
 MODULE_big = tcle
-OBJS       = tcle.o tcleheap.o aes.o kms.o
+OBJS       = tcle.o tcleheap.o aes.o kms.o utils.o
 REGRESS    = tcle
 
 PG_CONFIG ?= pg_config

--- a/tcle.c
+++ b/tcle.c
@@ -40,6 +40,7 @@
 #include "catalog/pg_type.h"
 #include "common/sha2.h"
 #include "commands/dbcommands.h"
+#include "commands/extension.h"
 #include "commands/progress.h"
 #include "libpq/pqformat.h"
 #include "miscadmin.h"
@@ -59,6 +60,7 @@
 #include "tcleheap.h"
 #include "aes.h"
 #include "kms.h"
+#include "utils.h"
 
 PG_MODULE_MAGIC;
 
@@ -746,13 +748,10 @@ static void
 get_encrypt_type_oids(Oid ** oidsPtr)
 {
 	Oid		namespaceId;
+	Oid		extensionId;
 
-	/*
-	 * FIXME: types Oid look up is done for "public" schema only, meaning that
-	 * if the extension is created within another schema, this lookup will
-	 * fail.
-	 */
-	namespaceId = get_namespace_oid("public", true);
+	extensionId = get_extension_oid("tcle", false);
+	namespaceId = get_extension_schema(extensionId);
 
 	for (int i = 0; i < N_ENCRYPT_TYPES; i++)
 	{

--- a/utils.c
+++ b/utils.c
@@ -1,0 +1,66 @@
+/*----------------------------------------------------------------------------
+ *
+ *                          TCLE utilities
+ *
+ * Portions Copyright (c) 2020, Julien Tachoires
+ * Portions Copyright (c) 1996-2020, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+  *
+ * IDENTIFICATION
+ *	  utils.c
+ *
+ * Utilities and functions from core source code that are not public in it.
+ *
+ *----------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include "access/genam.h"
+#include "access/htup_details.h"
+#include "access/table.h"
+#include "catalog/pg_extension.h"
+#include "catalog/pg_extension_d.h"
+#include "catalog/indexing.h"
+#include "commands/extension.h"
+#include "utils/fmgroids.h"
+
+#include "utils.h"
+
+/*
+ * get_extension_schema - given an extension OID, fetch its extnamespace
+ *
+ * Returns InvalidOid if no such extension.
+ */
+extern Oid
+get_extension_schema(Oid ext_oid)
+{
+	Oid			result;
+	Relation	rel;
+	SysScanDesc scandesc;
+	HeapTuple	tuple;
+	ScanKeyData entry[1];
+
+	rel = table_open(ExtensionRelationId, AccessShareLock);
+
+	ScanKeyInit(&entry[0],
+				Anum_pg_extension_oid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(ext_oid));
+
+	scandesc = systable_beginscan(rel, ExtensionOidIndexId, true,
+								  NULL, 1, entry);
+
+	tuple = systable_getnext(scandesc);
+
+	/* We assume that there can be at most one matching tuple */
+	if (HeapTupleIsValid(tuple))
+		result = ((Form_pg_extension) GETSTRUCT(tuple))->extnamespace;
+	else
+		result = InvalidOid;
+
+	systable_endscan(scandesc);
+
+	table_close(rel, AccessShareLock);
+
+	return result;
+}

--- a/utils.h
+++ b/utils.h
@@ -1,0 +1,6 @@
+#ifndef _UTILS_H_
+#define _UTILS_H_
+
+extern Oid get_extension_schema(Oid ext_oid);
+
+#endif


### PR DESCRIPTION
Before this commit, we considered the extension was created in the
default "public" schema. Now, the extension can be created in a
specific user defined schema.